### PR TITLE
fix: apply temp fix for react-native-navigation#1502

### DIFF
--- a/android/app/src/main/java/com/reactnativenavigation/views/LightBox.java
+++ b/android/app/src/main/java/com/reactnativenavigation/views/LightBox.java
@@ -107,7 +107,10 @@ public class LightBox extends Dialog implements DialogInterface.OnDismissListene
     }
 
     public void destroy() {
-        content.unmountReactView();
+        // FIXME: https://github.com/wix/react-native-navigation/issues/1502
+        // This is a temp fix and will leak memory by never unmounting react
+        // lightbox components, we only remove them from the native view heirarchy.
+        // content.unmountReactView();
         dismiss();
     }
 


### PR DESCRIPTION
From: https://github.com/wix/react-native-navigation/issues/1502#issuecomment-325946177

This is an awful "fix" but it's the only thing I can figure out that stops the crashes. It appears to be an issue with how `react-native-navigation` interacts with `react-native`, the stack trace that you get on crash actually comes from inside of `react-native`.

Note this will cause memory leaks and may cause some subtle bugs due to components in lightboxes not having their `componentWillUnmount` callback triggered.