### PR TITLE
fix: make FAB icon size larger

### DIFF
--- a/android/app/src/main/java/com/reactnativenavigation/views/FloatingActionButtonCoordinator.java
+++ b/android/app/src/main/java/com/reactnativenavigation/views/FloatingActionButtonCoordinator.java
@@ -13,6 +13,7 @@ import android.support.design.widget.FloatingActionButton;
 import android.util.Log;
 import android.view.Gravity;
 import android.view.View;
+import android.widget.ImageView;
 
 import com.reactnativenavigation.NavigationApplication;
 import com.reactnativenavigation.params.FabActionParams;
@@ -139,6 +140,7 @@ class FloatingActionButtonCoordinator {
         FloatingActionButton fab = new FloatingActionButton(parent.getContext());
         fab.setId(ViewUtils.generateViewId());
         fab.setImageDrawable(icon);
+        fab.setScaleType(ImageView.ScaleType.CENTER);
         return fab;
     }
 


### PR DESCRIPTION
Setting [`ScaleType.CENTER`](https://developer.android.com/reference/android/widget/ImageView.ScaleType.html) allows the FAB icon image to grow outside of its set bounds. I think this is because the FAB sets padding / margins on the ImageView that we actually want to ignore, so disabling scaling forces a larger size.

This resolves the issue with the FAB icon image being too small. We may want to wrap this scale toggle behind a FAB param if we need the standard 24dp sized FAB icons anywhere else in the application.